### PR TITLE
Update IdempotencyMiddleware.php

### DIFF
--- a/src/IdempotencyMiddleware.php
+++ b/src/IdempotencyMiddleware.php
@@ -15,13 +15,11 @@ class IdempotencyMiddleware
      */
     public function handle($request, Closure $next)
     {
-        if ($this->nonIndempotentRequest()) {
+        if (!$this->indempotentRequest()) {
             return $next($request);
         }
 
-        $cached = $this->requiresCaching($request, $next);
-
-        if (!$cached) {
+        if (!$this->requiresCaching($request, $next)) {
             return cache()->get(request()->header(config('idempotency.KEY_NAME')));
         }
 
@@ -31,9 +29,9 @@ class IdempotencyMiddleware
     /**
      * @return bool
      */
-    private function nonIndempotentRequest()
+    private function indempotentRequest()
     {
-        return !(
+        return (
             in_array(request()->getMethod(), config('idempotency.IDEMPOTENT_METHODS'))
             || request()->header(config('idempotency.KEY_NAME'))
         );


### PR DESCRIPTION
I think it makes more sense to have a method called `indempotentRequest` rather than `nonIndempotentRequest` and check that it isn't one in the first comparison.